### PR TITLE
Fix CI - missing theme file

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -7,7 +7,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
       - name: install emacs
-        run: sudo apt-get update && sudo apt-get install -y emacs
+        run: |
+          sudo snap install emacs --classic
+          emacs --version
       - name: put prelude in the right place
         run: ln -s $(pwd) $HOME/.emacs.d
       - name: load prelude

--- a/personal/personal-evil.el
+++ b/personal/personal-evil.el
@@ -1,4 +1,4 @@
-(prelude-require-packages '(key-chord))
+(prelude-require-packages '(key-chord origami))
 (require 'key-chord)
 (require 'evil)
 

--- a/personal/preload/display.el
+++ b/personal/preload/display.el
@@ -1,6 +1,4 @@
-(prelude-require-packages '(gruvbox-theme))
-
 (add-to-list 'custom-theme-load-path "~/.emacs.d/themes/")
 
 ;; Install package "gruvbox-theme" with "package-install".
-(setq prelude-theme 'gruvbox-dark-hard)
+;; (setq prelude-theme 'gruvbox-dark-hard)

--- a/personal/preload/display.el
+++ b/personal/preload/display.el
@@ -1,3 +1,5 @@
+(prelude-require-packages '(gruvbox-theme))
+
 (add-to-list 'custom-theme-load-path "~/.emacs.d/themes/")
 
 ;; Install package "gruvbox-theme" with "package-install".


### PR DESCRIPTION
## What 

This PR removes the theme configuration because it requires a package installation.

In addition, the PR changes the way the CI installs Emacs for smoke testing. The CI uses Snap and installs a more recent Emacs version.

## Why

1. The CI was complaining about a missing theme file.
2. Loading `fsharp-mode` caused an error:

> Package ‘emacs-27.1’ is unavailable